### PR TITLE
Fallback if algorithm not found

### DIFF
--- a/ulid4s/src/main/scala/net/petitviolet/ulid4s/ULID.scala
+++ b/ulid4s/src/main/scala/net/petitviolet/ulid4s/ULID.scala
@@ -1,12 +1,17 @@
 package net.petitviolet.ulid4s
 
-import java.security.SecureRandom
+import java.security.{ NoSuchAlgorithmException, SecureRandom }
 
 object ULID {
   private val self = {
     val timeSource = () => System.currentTimeMillis()
     val randGen = {
-      val random = SecureRandom.getInstance("NativePRNGNonBlocking")
+      val random = try {
+        SecureRandom.getInstance("NativePRNGNonBlocking")
+      } catch {
+        case _: NoSuchAlgorithmException =>
+          SecureRandom.getInstanceStrong()
+      }
       // random.setSeed(java.util.UUID.randomUUID().toString.getBytes)
       () =>
         random.nextDouble()


### PR DESCRIPTION
`NativePRNGNonBlocking` may be unavailable on Windows system.
This PR add fallback using [`getInstanceStrong`](https://docs.oracle.com/javase/8/docs/api/java/security/SecureRandom.html#getInstanceStrong--), which works on Windows.
It may return blocking algorihm, so not appropriate for first-call.